### PR TITLE
Update projects to .NET 10.0 and adjust target platforms

### DIFF
--- a/Promise.Comp/Promise.Comp.csproj
+++ b/Promise.Comp/Promise.Comp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-	  <TargetFramework>net9.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Promise.Lib/Promise.Lib.csproj
+++ b/Promise.Lib/Promise.Lib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net9.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Promise.Native/Promise.Native.csproj
+++ b/Promise.Native/Promise.Native.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-		<!--<TargetFrameworks>net10.0-android;</TargetFrameworks>-->
-		<!--<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>-->
-		
-		<TargetFrameworks>net9.0-ios;</TargetFrameworks>
+		<TargetFrameworks>net10.0-android;</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+
+		<!--<TargetFrameworks>net10.0-ios;</TargetFrameworks>-->
 		<!--<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks> -->
         <!-- Note for MacCatalyst:
             The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.


### PR DESCRIPTION
Upgraded Promise.Comp and Promise.Lib to .NET 10.0. Changed Promise.Native to target net10.0-android by default, with conditional support for net10.0-windows. Commented out previous net9.0-ios target.