### PR TITLE
Enforce code style, update packages, and adjust Android settings - Native App ver. 2.0.12 (build 51)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AnalysisMode>All</AnalysisMode>
-	<LangVersion>latest</LangVersion>
+	<LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,16 +1,17 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="MailKit" Version="4.16.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.51" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.51" />
-    <PackageVersion Include="MimeKit" Version="4.16.0" />
-    <PackageVersion Include="NLog" Version="6.1.2" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.1" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageVersion Include="MailKit" Version="4.17.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.80" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.80" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="3.8.0" />
+    <PackageVersion Include="MimeKit" Version="4.17.0" />
+    <PackageVersion Include="NLog" Version="6.1.4" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.11" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.80" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageVersion Include="MimeKit" Version="4.17.0" />
     <PackageVersion Include="NLog" Version="6.1.4" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.16.11" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.80" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="3.8.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="MimeKit" Version="4.17.0" />
     <PackageVersion Include="NLog" Version="6.1.4" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.16.11" />

--- a/Promise.Api/Promise.Api.csproj
+++ b/Promise.Api/Promise.Api.csproj
@@ -24,6 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="MailKit" />
     <PackageReference Include="MimeKit" />
     <PackageReference Include="Scalar.AspNetCore" />

--- a/Promise.Api/Promise.Api.csproj
+++ b/Promise.Api/Promise.Api.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <AssemblyVersion>2.0.11</AssemblyVersion>
     <UserSecretsId>promise-api-secrets</UserSecretsId>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-all</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Promise.Common/Promise.Common.csproj
+++ b/Promise.Common/Promise.Common.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-all</AnalysisLevel>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="NLog" />

--- a/Promise.Comp/Promise.Comp.csproj
+++ b/Promise.Comp/Promise.Comp.csproj
@@ -1,6 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
 
+  <PropertyGroup>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-all</AnalysisLevel>
+  </PropertyGroup>
+
+
   <ItemGroup>
     <SupportedPlatform Include="browser" />
   </ItemGroup>

--- a/Promise.Native/App.xaml.cs
+++ b/Promise.Native/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿namespace Promise.Native;
 
 [SuppressMessage("Maintainability", "CA1515:Consider making public types internal", Justification = "Must be public for XAML binding in MAUI projects")]
+[SuppressMessage("Naming", "CA1724:Type names should not match namespaces", Justification = "App is the standard application class name in MAUI projects")]
 public partial class App : Application
 {
 	public static string? PendingPaymentToken { get; set; }

--- a/Promise.Native/Promise.Native.csproj
+++ b/Promise.Native/Promise.Native.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
+		<!--<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>-->
+		<TargetFrameworks>net10.0-android</TargetFrameworks>		
+		
 		<!--<TargetFrameworks>net10.0-android;net10.0-ios;</TargetFrameworks>-->
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 
 		<!--<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks> -->
         <!-- Note for MacCatalyst:
@@ -25,14 +27,14 @@
         <ApplicationId>app.YouCent</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>2.0.11</ApplicationDisplayVersion>
-        <ApplicationVersion>50</ApplicationVersion>
+        <ApplicationDisplayVersion>2.0.12</ApplicationDisplayVersion>
+        <ApplicationVersion>51</ApplicationVersion>
 
         <WindowsPackageType>MSIX</WindowsPackageType>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">27.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<DefaultLanguage>en-us</DefaultLanguage>
@@ -45,6 +47,7 @@
 			<DebugSymbols>true</DebugSymbols>
 			<AndroidIncludeDebugSymbols>true</AndroidIncludeDebugSymbols>
 		</PropertyGroup>
+
 
     <ItemGroup>
         <!-- App Icon -->

--- a/Promise.Native/Promise.Native.csproj
+++ b/Promise.Native/Promise.Native.csproj
@@ -36,6 +36,8 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<DefaultLanguage>en-us</DefaultLanguage>
+		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+		<AnalysisLevel>latest-all</AnalysisLevel>
 
 		</PropertyGroup>
 

--- a/Promise.Web/Promise.Web.csproj
+++ b/Promise.Web/Promise.Web.csproj
@@ -1,7 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <AssemblyVersion>2.0.3</AssemblyVersion>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-all</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated packages for security reasons and Android target bumped.